### PR TITLE
Fixed handling of exceptions, such as socket.timeout

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -477,7 +477,13 @@ class socksocket(socket.socket):
             self.close()
             proxy_server = "{}:{}".format(proxy_addr.decode(), proxy_port)
             printable_type = PRINTABLE_PROXY_TYPES[proxy_type]
-            errno, msg = error.args
-            msg = "Error connecting to {} proxy {}: {}".format(printable_type,
-                                                               proxy_server, msg)
-            raise socket.error(errno, msg)
+            mkmsg = lambda msg: "Error connecting to {} proxy {}: {}".format(printable_type,
+                                                                             proxy_server, msg)
+            if len(error.args) == 0:
+                args = (mkmsg(None),)
+            elif len(error.args) == 1:
+                args = (mkmsg(error.args[0]),)
+            else:
+                args = tuple(error.args)
+                args = args[:1] + (mkmsg(args[1]),) + args[2:]
+            raise socket.error(*args)


### PR DESCRIPTION
Exceptions do not always have errno or msg, so we need to handle all possible cases.
Below, you can see an example of errors without fixing this:

```
...
            return opener.open(request, timeout=timeout).read()
          File "/usr/lib/python3.3/urllib/request.py", line 469, in open
            response = self._open(req, data)
          File "/usr/lib/python3.3/urllib/request.py", line 487, in _open
            '_open', req)
          File "/usr/lib/python3.3/urllib/request.py", line 447, in _call_chain
            result = func(*args)
          File "/usr/lib/python3.3/site-packages/ulib/network/url.py", line 76, in http_open
            return self.do_open(build, request)
          File "/usr/lib/python3.3/urllib/request.py", line 1248, in do_open                                                                                                
            h.request(req.get_method(), req.selector, req.data, headers)                                                                                                    
          File "/usr/lib/python3.3/http/client.py", line 1061, in request                                                                                                   
            self._send_request(method, url, body, headers)
          File "/usr/lib/python3.3/http/client.py", line 1099, in _send_request
            self.endheaders(body)
          File "/usr/lib/python3.3/http/client.py", line 1057, in endheaders
            self._send_output(message_body)
          File "/usr/lib/python3.3/http/client.py", line 902, in _send_output
            self.send(msg)
          File "/usr/lib/python3.3/http/client.py", line 840, in send
            self.connect()
          File "/usr/lib/python3.3/site-packages/ulib/network/url.py", line 65, in connect
            self.sock.connect((self.host, self.port))
          File "/usr/lib/python3.3/site-packages/socks.py", line 480, in connect
            errno, msg = error.args
        ValueError: need more than 1 value to unpack
```
