### PR TITLE
UDP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Updated version of SocksiPy. Many old bugs fixed, and overall code cleanup.
 Features
 ========
 
-* Fully supports Python 2.6 - 3.4. (UDP support requires Python 3.)
+* Fully supports Python 2.6 - 3.4
 
 * SocksiPyHandler, courtesy e000, was also added as an example of how this module can be used with urllib2. See example code in sockshandler.py.
 


### PR DESCRIPTION
This adds support for sending and receiving UDP packets with a SOCKS5 proxy.

I reworked the code a fair amount, so that I could reuse some of the existing SOCKS5 code. For instance, _recvall() is now _readall() and works on a socket.makefile() or BytesIO object rather than the raw socket. Let me know if you aren’t comfortable with this refactoring, and I could try to tone it down a bit.

Another point is that my UDP code only works with Python 3. Python 2’s _socket_ class sets the sendto() etc methods as instance attributes (rather than class attributes), defeating the normal way of overriding methods. I’m not really motivated to make it work for Python 2 unless there is a really simple workaround.

I should add some tests, but haven’t got around to it. Would you be interested if I converted the test suite to use Python’s standard _unittest_ framework? It should be more maintainable and flexible that way.
