### PR TITLE
Fix unexpected keyword argument in Python 3

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -207,12 +207,12 @@ class socksocket(_BaseSocket):
 
     default_proxy = None
 
-    def __init__(self, family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0, _sock=None):
+    def __init__(self, family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0, *args, **kwargs):
         if type not in (socket.SOCK_STREAM, socket.SOCK_DGRAM):
             msg = "Socket type must be stream or datagram, not {!r}"
             raise ValueError(msg.format(type))
 
-        _BaseSocket.__init__(self, family, type, proto, _sock)
+        _BaseSocket.__init__(self, family, type, proto, *args, **kwargs)
         self._proxyconn = None  # TCP connection to keep UDP relay alive
 
         if self.default_proxy:


### PR DESCRIPTION
`socket.socket()`'s undocumented last argument differs between Python 2 and 3.

In Python 2.7.10, the last argument is `_sock`.

```
def __init__(self, family=AF_INET, type=SOCK_STREAM, proto=0, _sock=None):
```

https://hg.python.org/cpython/file/15c95b7d81dc/Lib/socket.py#l189

But in Python 3.4.3, the last argument is `fileno`.

```
def __init__(self, family=AF_INET, type=SOCK_STREAM, proto=0, fileno=None):
```

https://hg.python.org/cpython/file/b4cbecbc0781/Lib/socket.py#l121

As socksocket uses Python 2 style, unexpected keyword argument error is raised when `socket.dup()` or `socket.accept()` is called. 

This fix uses `*args` and `**kwargs` to support both Python 2 and 3.

Note that I'm using PySocks with [paho-mqtt](https://pypi.python.org/pypi/paho-mqtt) to connect to an MQTT server through a socks proxy.