### PR TITLE
Support dual-stack IPv4/IPv6 environments

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -625,6 +625,12 @@ class socksocket(_BaseSocket):
 
         dest_pair - 2-tuple of (IP/hostname, port).
         """
+        if len(dest_pair) != 2:
+            # Probably IPv6, not supported -- raise an error, and hope
+            # Happy Eyeballs (RFC6555) makes sure at least the IPv4
+            # connection works...
+            raise socket.error("SocksPy doesn't support IPv6")
+
         dest_addr, dest_port = dest_pair
 
         if self.type == socket.SOCK_DGRAM:

--- a/test/sockstest.py
+++ b/test/sockstest.py
@@ -135,38 +135,49 @@ def global_override_SOCKS5_test():
     assert status == 200
     assert socks.get_default_proxy()[1].decode() == default_proxy[1]
 
+def bail_early_with_ipv6_test():
+    sock = socks.socksocket()
+    ipv6_tuple = addr, port, flowinfo, scopeid = "::1", 1234, 0, 0
+    try:
+        sock.connect(ipv6_tuple)
+    except socket.error:
+        return
+    else:
+        assert False, "was expecting"
 
 def main():
     print("Running tests...")
     socket_HTTP_test()
-    print("1/12")
+    print("1/13")
     socket_SOCKS4_test()
-    print("2/12")
+    print("2/13")
     socket_SOCKS5_test()
-    print("3/12")
+    print("3/13")
     if not PY3K:
         urllib2_handler_HTTP_test()
-        print("3.33/12")
+        print("3.33/13")
         urllib2_handler_SOCKS5_test()
-        print("3.66/12")
+        print("3.66/13")
     socket_HTTP_IP_test()
-    print("4/12")
+    print("4/13")
     socket_SOCKS4_IP_test()
-    print("5/12")
+    print("5/13")
     socket_SOCKS5_IP_test()
-    print("6/12")
+    print("6/13")
     SOCKS5_connect_timeout_test()
-    print("7/12")
+    print("7/13")
     SOCKS5_timeout_test()
-    print("8/12")
+    print("8/13")
     urllib2_HTTP_test()
-    print("9/12")
+    print("9/13")
     urllib2_SOCKS5_test()
-    print("10/12")
+    print("10/13")
     global_override_HTTP_test()
-    print("11/12")
+    print("11/13")
     global_override_SOCKS5_test()
-    print("12/12")
+    print("12/13")
+    bail_early_with_ipv6_test()
+    print("13/13")
     print("All tests ran successfully")
 
 


### PR DESCRIPTION
`socket.create_connection` implements Happy Eyeballs/RFC6555. This means that on dual-stack machines, it's impossible to connect to a lot of hosts, even though IPv4 actually works. The workaround for this is to just synchronously raise `socket.error` instead of the `ValueError` we'd otherwise get. This way, the Happy Eyeballs algorithm knows that IPv6 doesn't work -- but as long as IPv4 works, the connection succeeds.

This is an important patch, because in many other contexts it's impossible to work around. Suppose that you want to connect to `http://www.company.example` using urllib2. Before this patch, you can't even connect to that host by manually resolving the IPv4 address and using that (e.g. `http://1.2.3.4`), because:

1. Your client will submit a Host header
2. The server will almost certainly redirect you to the actual hostname
3. You will resolve the actual hostname, and find an A and AAAA record
4. Happy Eyeballs tries both the IPv4 and IPv6 addresses simultaneously
5. Everything blows up because PySocks doesn't support the IPv6 connection

With this patch, everything is the same except part 5, where *only* the IPv6 connection blows up using `socket.error`, in which case, Happy Eyeballs falls back to just trying the IPv4 connection.
