### PR TITLE
Additional space.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ class `HTTPError` - This will be raised for HTTP errors. The message will contai
 the HTTP status code and provided error message.
 
 After establishing the connection, the object behaves like a standard socket.
+
 Methods like `makefile()` and `settimeout()` should behave just like regular sockets.
 Call the `close()` method to close the connection.
 


### PR DESCRIPTION
These two sentences together were misleading. I've added extra space to separate the, so you wouldn't use `settimeout` **after** connection is established ;)