### PR TITLE
RDNS and Resolve Local fixes

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -529,7 +529,7 @@ class socksocket(_BaseSocket):
             file.write(b"\x03" + chr(len(host_bytes)).encode() + host_bytes)
         else:
             # Resolve locally
-            addresses = socket.getaddrinfo(host, port)
+            addresses = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM, socket.IPPROTO_TCP, socket.AI_ADDRCONFIG)
             # We can't really work out what IP is reachable, so just pick the
             # first.
             target_addr = addresses[0]
@@ -539,8 +539,8 @@ class socksocket(_BaseSocket):
             addr_bytes = socket.inet_pton(family, host)
             file.write(family_to_byte[family] + addr_bytes)
             host = socket.inet_ntop(family, addr_bytes)
-            file.write(struct.pack(">H", port))
-            return host, port
+        file.write(struct.pack(">H", port))
+        return host, port
 
     def _read_SOCKS5_address(self, file):
         atyp = self._readall(file, 1)


### PR DESCRIPTION
Fixed missing port write to proxy when doing RDNS due to indent error. Added additional socket params so only addresses supported by the local interface family are returned.  This allows ipv4/ipv6 addresses to be returned only if the local system has the respective family configured, preventing lookup failures