### PR TITLE
workaround non-blocking issues with TCP

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -258,6 +258,8 @@ class socksocket(_BaseSocket):
         self.proxy_sockname = None
         self.proxy_peername = None
 
+        self.timeout = None
+
     def _readall(self, file, count):
         """
         Receive EXACTLY the number of bytes requested from the file object.
@@ -270,6 +272,24 @@ class socksocket(_BaseSocket):
                 raise GeneralProxyError("Connection closed unexpectedly")
             data += d
         return data
+
+    def settimeout(self, timeout):
+        self.timeout = timeout
+        try:
+            # test if we're connected, if so apply timeout
+            peer = self.get_proxy_peername()
+            _BaseSocket.settimeout(self, self.timeout)
+        except socket.error:
+            pass
+
+    def gettimeout(self):
+        return self.timeout
+
+    def setblocking(self, v):
+        if v:
+            self.settimeout(None)
+        else:
+            self.settimeout(0.0)
 
     def set_proxy(self, proxy_type=None, addr=None, port=None, rdns=True, username=None, password=None):
         """set_proxy(proxy_type, addr[, port[, rdns[, username[, password]]]])
@@ -329,6 +349,7 @@ class socksocket(_BaseSocket):
         host, _ = proxy
         _, port = relay
         _BaseSocket.connect(self, (host, port))
+        _BaseSocket.settimeout(self, self.timeout)
         self.proxy_sockname = ("0.0.0.0", 0)  # Unknown
 
     def sendto(self, bytes, *args, **kwargs):
@@ -495,6 +516,8 @@ class socksocket(_BaseSocket):
 
             # Get the bound address/port
             bnd = self._read_SOCKS5_address(reader)
+
+            _BaseSocket.settimeout(self, self.timeout)
             return (resolved, bnd)
         finally:
             reader.close()
@@ -745,6 +768,7 @@ class socksocket(_BaseSocket):
                 # Calls negotiate_{SOCKS4, SOCKS5, HTTP}
                 negotiate = self._proxy_negotiators[proxy_type]
                 negotiate(self, dest_addr, dest_port)
+                _BaseSocket.settimeout(self, self.timeout)
             except socket.error as error:
                 # Wrap socket errors
                 self.close()


### PR DESCRIPTION
The following snippet fails with TCP because dns is using setblocking(False) before calling connect:
```
#!/usr/bin/env python

import socks

import dns.dnssec
import dns.exception
import dns.flags
import dns.message
import dns.name
import dns.query
import dns.rcode
import dns.rdataclass
import dns.rdatatype
import dns.resolver

socks.set_default_proxy(socks.SOCKS5, '127.0.0.1', 1080, False)
dns.query.socket.socket = socks.socksocket

if __name__ == '__main__':
    rdclass = dns.rdataclass.IN
    rdtype = dns.rdatatype.A
    qname = dns.name.from_text('www')
    req = dns.message.make_query(qname, rdtype, rdclass)

    print dns.query.udp(req, '8.8.8.8', 1, 53)
    print dns.query.tcp(req, '8.8.8.8', 1, 53)
```

```
Traceback (most recent call last):
  File "./break.py", line 26, in <module>
    print dns.query.tcp(req, '8.8.8.8', 1, 53)
  File "/home/pb/.local/lib/python2.7/site-packages/dns/query.py", line 308, in tcp
    _connect(s, destination)
  File "/home/pb/.local/lib/python2.7/site-packages/dns/query.py", line 264, in _connect
    s.connect(address)
  File "/home/pb/git/PySocks/socks.py", line 740, in connect
    raise ProxyConnectionError(msg, error)
socks.ProxyConnectionError:
```

Attached is an attempt to fix it -