### PR TITLE
workaround nonblocking connects

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -258,6 +258,8 @@ class socksocket(_BaseSocket):
         self.proxy_sockname = None
         self.proxy_peername = None
 
+        self._timeout = None
+
     def _readall(self, file, count):
         """
         Receive EXACTLY the number of bytes requested from the file object.
@@ -270,6 +272,24 @@ class socksocket(_BaseSocket):
                 raise GeneralProxyError("Connection closed unexpectedly")
             data += d
         return data
+
+    def settimeout(self, timeout):
+        self._timeout = timeout
+        try:
+            # test if we're connected, if so apply timeout
+            peer = self.get_proxy_peername()
+            _BaseSocket.settimeout(self, self._timeout)
+        except socket.error:
+            pass
+
+    def gettimeout(self):
+        return self._timeout
+
+    def setblocking(self, v):
+        if v:
+            self.settimeout(None)
+        else:
+            self.settimeout(0.0)
 
     def set_proxy(self, proxy_type=None, addr=None, port=None, rdns=True, username=None, password=None):
         """set_proxy(proxy_type, addr[, port[, rdns[, username[, password]]]])
@@ -329,6 +349,7 @@ class socksocket(_BaseSocket):
         host, _ = proxy
         _, port = relay
         _BaseSocket.connect(self, (host, port))
+        _BaseSocket.settimeout(self, self._timeout)
         self.proxy_sockname = ("0.0.0.0", 0)  # Unknown
 
     def sendto(self, bytes, *args, **kwargs):
@@ -495,6 +516,8 @@ class socksocket(_BaseSocket):
 
             # Get the bound address/port
             bnd = self._read_SOCKS5_address(reader)
+
+            _BaseSocket.settimeout(self, self._timeout)
             return (resolved, bnd)
         finally:
             reader.close()
@@ -719,6 +742,7 @@ class socksocket(_BaseSocket):
         if proxy_type is None:
             # Treat like regular socket object
             self.proxy_peername = dest_pair
+            _BaseSocket.settimeout(self, self._timeout)
             _BaseSocket.connect(self, (dest_addr, dest_port))
             return
 
@@ -745,6 +769,7 @@ class socksocket(_BaseSocket):
                 # Calls negotiate_{SOCKS4, SOCKS5, HTTP}
                 negotiate = self._proxy_negotiators[proxy_type]
                 negotiate(self, dest_addr, dest_port)
+                _BaseSocket.settimeout(self, self._timeout)
             except socket.error as error:
                 # Wrap socket errors
                 self.close()


### PR DESCRIPTION
it would probably be too hard to piggyback on the caller's
handling of non blocking sockets to really handle a non-blocking
negociation - delay the timeout until we negociated.

side-effect for callers: blocking on connect in event loops, which
is very bad.

```
#!/usr/bin/env python

import socks
import socket
import errno

socks.set_default_proxy(socks.SOCKS5, '127.0.0.1', 1080, False)
socket.socket = socks.socksocket

if __name__ == '__main__':
    so = socket.socket(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP)
    so.setblocking(0)
    try:
        so.connect(('test.host',53))
    except socket.error as e:
        if e.args[0] == errno.EINPROGRESS:
            pass

    print(so.getsockname())
```

(consider this a weak proposal, I already messed up on py3)
