### PR TITLE
Adding Windows compatibility

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -59,8 +59,20 @@ import struct
 from errno import EOPNOTSUPP, EINVAL, EAGAIN
 from io import BytesIO
 from os import SEEK_CUR
+import os
 from collections import Callable
 from base64 import b64encode
+
+
+if os.name == 'nt':
+    try:
+        import win_inet_pton
+        import socket
+    except ImportError:
+        raise ImportError('To run PySocks under windows you need to install win_inet_pton') 
+else:
+    import socket
+
 
 PROXY_TYPE_SOCKS4 = SOCKS4 = 1
 PROXY_TYPE_SOCKS5 = SOCKS5 = 2


### PR DESCRIPTION
Under Windows the module was failing because Python < 3 doesn't include
socket.inet_ntop & socket.inet_pton functions. (See issue #47 )

This modification adds the Windows functionality and notifies the user if the win_inet_pton module is missing. 
(would be better to add a requirement for win_inet_pton in the setup.py script, but I have no idea how to make different requirements for different OSes)
