### PR TITLE
Timeout earlier in connection.

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -748,6 +748,10 @@ class socksocket(_BaseSocket):
             raise GeneralProxyError("Invalid destination-connection (host, port) pair")
 
 
+        # We set the timeout here so that we don't hang in connection or during
+        # negotiation.
+        _BaseSocket.settimeout(self, self._timeout)
+
         if proxy_type is None:
             # Treat like regular socket object
             self.proxy_peername = dest_pair
@@ -758,7 +762,7 @@ class socksocket(_BaseSocket):
         proxy_addr = self._proxy_addr()
 
         try:
-            # Initial connection to proxy server
+            # Initial connection to proxy server.
             _BaseSocket.connect(self, proxy_addr)
 
         except socket.error as error:
@@ -778,7 +782,6 @@ class socksocket(_BaseSocket):
                 # Calls negotiate_{SOCKS4, SOCKS5, HTTP}
                 negotiate = self._proxy_negotiators[proxy_type]
                 negotiate(self, dest_addr, dest_port)
-                _BaseSocket.settimeout(self, self._timeout)
             except socket.error as error:
                 # Wrap socket errors
                 self.close()


### PR DESCRIPTION
It is possible when setting timeouts on socksocket objects to find that they hang indefinitely during connection or negotiation. This is a less-than-ideal user experience. This change moves the socket timeout setting earlier in the connection setup so that it applies to the actual TCP connection and the negotiation, if there is any.

For the moment I haven't written any tests because this would require some extra logic to handle. Let me know if that's something you actually want and I can invest the time to write those tests.