### PR TITLE
Use super() instead of hardcoding a class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Brief descriptions of changes will be logged here. Note that unless otherwise specified, all future versions should be backwards compatible with older versions.
 
+## [1.6.7] - Unreleased
+- Compatibility with gevent. See issue #61.
+
 ## [1.6.6] - 2017-01-29
 - Full test suite finally added
 - Travis CI enabled for project


### PR DESCRIPTION
This should make us more compatible with alternate socket implementations, in particular gevent's.

Fixes #61.

(I couldn't run the tests locally, so this may take an iteration or two on Travis.)