### PR TITLE
Use test_server==0.0.26 for testing

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,3 @@
 six
-test_server
+test_server==0.0.26
 psutil

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34
+envlist = py2,py3
 
 [testenv]
 commands =


### PR DESCRIPTION
Use exact version of test server to avoid possible compatibility errors with future versions of test_server