### PR TITLE
Make SocksiPy legacy functions kwarg-compatible

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -131,7 +131,10 @@ def set_default_proxy(proxy_type=None, addr=None, port=None, rdns=True, username
                                 username.encode() if username else None,
                                 password.encode() if password else None)
 
-setdefaultproxy = set_default_proxy
+def setdefaultproxy(*args, **kwargs):
+    if 'proxytype' in kwargs:
+        kwargs['proxy_type'] = kwargs.pop('proxytype')
+    return set_default_proxy(*args, **kwargs)
 
 def get_default_proxy():
     """
@@ -321,7 +324,10 @@ class socksocket(_BaseSocket):
                       username.encode() if username else None,
                       password.encode() if password else None)
 
-    setproxy = set_proxy
+    def setproxy(self, *args, **kwargs):
+        if 'proxytype' in kwargs:
+            kwargs['proxy_type'] = kwargs.pop('proxytype')
+        return self.set_proxy(*args, **kwargs)
 
     def bind(self, *pos, **kw):
         """


### PR DESCRIPTION
Ran across this when trying to use PySocks as a drop-in for SocksiPy. 298d7c9 renamed a bunch of methods and aliased them to their old names, however it changed one of the kwargs for setproxy() and setdefaultproxy() which breaks any invocations explicitly using the old kwargs.

This is pretty minor and I'm unsure if it's worth the trouble to fix so feel free to close if necessary