### PR TITLE
feat(log): also report negotiations error in WARN level

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -730,6 +730,21 @@ class socksocket(_BaseSocket):
                            HTTP: _negotiate_HTTP
                          }
 
+    def _prepare_error_msg(self, proxy_addr, action, error):
+        proxy_type = self.proxy[0]
+        try:
+            proxy_addr, proxy_port = proxy_addr
+            proxy_server = "{0}:{1}".format(proxy_addr, proxy_port)
+        except ValueError:
+            proxy_server = proxy_addr
+        printable_type = PRINTABLE_PROXY_TYPES[proxy_type]
+
+        msg = "Failed %s to %s-proxy(%s) due to: %s: %s" % (
+            action, printable_type, proxy_server,
+            type(error).__name__, error)
+
+        return msg
+
     @set_self_blocking
     def connect(self, dest_pair):
         """
@@ -794,9 +809,8 @@ class socksocket(_BaseSocket):
             proxy_server = "{0}:{1}".format(proxy_addr, proxy_port)
             printable_type = PRINTABLE_PROXY_TYPES[proxy_type]
 
-            msg = "Error connecting to {0} proxy {1}".format(printable_type,
-                                                           proxy_server)
-            log.debug("%s due to: %s", msg, error)
+            msg = self._prepare_error_msg(proxy_addr, 'connecting', error)
+            log.warning(msg)
             raise ProxyConnectionError(msg, error)
 
         else:
@@ -808,10 +822,14 @@ class socksocket(_BaseSocket):
             except socket.error as error:
                 # Wrap socket errors
                 self.close()
-                raise GeneralProxyError("Socket error", error)
-            except ProxyError:
+                msg = self._prepare_error_msg(proxy_addr, 'negotiating', error)
+                log.warning(msg)
+                raise GeneralProxyError(msg, error)
+            except ProxyError as error:
                 # Protocol error while negotiating with proxy
                 self.close()
+                msg = self._prepare_error_msg(proxy_addr, 'negotiating', error)
+                log.warning(msg)
                 raise
 
     def _proxy_addr(self):


### PR DESCRIPTION
- Like #70, but also for negotiation errors (e.g. user/pswd denied
messages).
- Increase log-level from DEBUG-->WARNING because if dest-address
resolves to multiple IPs, practically that is the only place where the
real failure-cause it is reported.
- Correct way should have been to log from within Python's
`socket.create_connection()`.
- FIX `ProxyError` exception that did not set `args` and, among others, repr() is empty.