### PR TITLE
chore(build): use setuptools in setup.py to support wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from distutils.core import setup
+from setuptools import setup
 
 VERSION = "1.6.6"
 


### PR DESCRIPTION
Just by changing a single line, now it is possible to build and deploy "wheels" in PyPi,
with this `python setup.py bdist_wheel` in cmd-line.

The commands to build and deploy "wheels" in PyPi, are these:

```bash
python setup.py bdist_wheel
twine upload -s dist/*
```