### PR TITLE
Include win_inet_pton when installing on Python 2.x under Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python
+import os
+import sys
 from setuptools import setup
 
 VERSION = "1.6.7"
+
+requirements = []
+if os.name == "nt" and sys.version_info < (3, 0):
+    # Required due to missing socket.inet_ntop & socket.inet_pton method in Windows Python 2.x
+    requirements.append("win-inet-pton")
 
 setup(
     name = "PySocks",
@@ -12,5 +19,6 @@ setup(
     author = "Anorov",
     author_email = "anorov.vorona@gmail.com",
     keywords = ["socks", "proxy"],
-    py_modules=["socks", "sockshandler"]
+    py_modules=["socks", "sockshandler"],
+    install_requires=requirements
 )


### PR DESCRIPTION
This patch will cause `win_inet_pton` to be added as a dependency when installing PySocks on Windows when using Python 2.x. See #50 (and #47) where the need for `win_inet_pton` was discussed, but was not added as a conditional dependency. 

This could be done using the superior [Environment Markers](https://www.python.org/dev/peps/pep-0508/#environment-markers) syntax, eg.`win-inet-pton; os.name == 'nt' and python_version < '3.0'` but this could cause some backwards compatibility issues.