### PR TITLE
Fix tox testing on travis for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,16 @@ os:
 
 env:
   - TOX_ENV=py27
-  - TOX_ENV=py33
   - TOX_ENV=py34
 
-# For python3.5 and python3.6 the base python versions
-# should be 3.5 and 3.6 accordingly to avoid InterpreterNotFound error
+# For python3.3, python3.5, and python3.6 the base python versions
+# should be 3.3, 3.5 and 3.6 accordingly to avoid InterpreterNotFound error
 matrix:
   allow_failures:
     - env: TOX_ENV=qa
   include:
+    - python: 3.3
+      env: TOX_ENV=py33
     - python: 3.4
       env: TOX_ENV=qa
     - python: 3.5


### PR DESCRIPTION
The Python 3.3 base version needs to be used to get py33 to work with tox on travis. 