### PR TITLE
Make wrap_module patch socket.getaddrinfo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ To monkeypatch the entire standard library with a single default proxy:
     import urllib2
     import socket
     import socks
+    import sys
 
     socks.set_default_proxy(socks.SOCKS5, "localhost")
-    socket.socket = socks.socksocket
+    socks.wrap_module(sys.modules[__name__])
 
     urllib2.urlopen("http://www.somesite.com/") # All requests will pass through the SOCKS proxy
 

--- a/socks.py
+++ b/socks.py
@@ -86,7 +86,7 @@ PROXY_TYPES = {"SOCKS4": SOCKS4, "SOCKS5": SOCKS5, "HTTP": HTTP}
 PRINTABLE_PROXY_TYPES = dict(zip(PROXY_TYPES.values(), PROXY_TYPES.keys()))
 
 _orgsocket = _orig_socket = socket.socket
-
+_orig_getaddrinfo = socket.getaddrinfo
 
 def set_self_blocking(function):
 
@@ -188,6 +188,15 @@ def get_default_proxy():
 
 getdefaultproxy = get_default_proxy
 
+# https://web.archive.org/web/20161211104525/http://fitblip.pub/2012/11/13/proxying-dns-with-python/
+def getaddrinfo(*args):
+    (proxy_type, proxy_addr, proxy_port, rdns, username,
+         password) = get_default_proxy()
+
+    if proxy_type is not None and rdns:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', (args[0], args[1]))]
+
+    return _orig_getaddrinfo(*args)
 
 def wrap_module(module):
     """Attempts to replace a module's socket library with a SOCKS socket.
@@ -196,6 +205,7 @@ def wrap_module(module):
     only work on modules that import socket directly into the namespace;
     most of the Python Standard Library falls into this category."""
     if socksocket.default_proxy:
+        module.socket.getaddrinfo = getaddrinfo
         module.socket.socket = socksocket
     else:
         raise GeneralProxyError("No default proxy specified")


### PR DESCRIPTION
Good day!

I'm developing a proxy leak detection tool, and thought it would be a fun challenge to use it to investigate #22.  And happily it looks like I was successful.  This PR makes `wrap_module` patch `socket.getaddrinfo` (preventing DNS leaks from that function), and updates the monkeypatching documentation accordingly.

I opted to use the workaround at https://github.com/Anorov/PySocks/issues/22#issuecomment-122581733 rather than the workaround at https://github.com/Anorov/PySocks/issues/22#issuecomment-279759939 , because the latter only works with SOCKS proxies that support Tor's nonstandard protocol extensions.  The latter is definitely preferable if the user is certain that their proxy supports Tor's extensions; a future PR could give the user an option to choose which is used.

It's entirely possible that I've subtly broken something, as I'm not intimately familiar with the Python socket codebase, but it seems to work acceptably in my testing.

Cheers!