### PR TITLE
Add python version classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,10 @@ setup(
     author_email = "anorov.vorona@gmail.com",
     keywords = ["socks", "proxy"],
     py_modules=["socks", "sockshandler"],
-    install_requires=requirements
+    install_requires=requirements,
+    classifiers=(
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+    )
 )


### PR DESCRIPTION
Make it easy to pragmatically determine this supports python3 via
https://github.com/brettcannon/caniusepython3.

caniusepython3 is formally recommended by
https://docs.python.org/3/howto/pyporting.html