### PR TITLE
Make create_connection() signature match socket module

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -203,10 +203,11 @@ def wrap_module(module):
 wrapmodule = wrap_module
 
 
-def create_connection(dest_pair, proxy_type=None, proxy_addr=None,
+def create_connection(dest_pair,
+                      timeout=None, source_address=None,
+                      proxy_type=None, proxy_addr=None,
                       proxy_port=None, proxy_rdns=True,
                       proxy_username=None, proxy_password=None,
-                      timeout=None, source_address=None,
                       socket_options=None):
     """create_connection(dest_pair, *[, timeout], **proxy_args) -> socket object
 


### PR DESCRIPTION
This is necessary for modules that call `create_connection()` with `timeout` and `source_address` used as positional parameters, like `http.client`.