### PR TITLE
Use README.md as description on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,15 @@ if os.name == "nt" and sys.version_info < (3, 0):
     # Required due to missing socket.inet_ntop & socket.inet_pton method in Windows Python 2.x
     requirements.append("win-inet-pton")
 
+with open('README.md') as f:
+    long_description = f.read()
+
 setup(
     name = "PySocks",
     version = VERSION,
     description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information.",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     url = "https://github.com/Anorov/PySocks",
     license = "BSD",
     author = "Anorov",


### PR DESCRIPTION
Right now https://pypi.org/project/PySocks/ looks like:

![image](https://user-images.githubusercontent.com/1324225/43123224-2eec80d2-8f2c-11e8-8785-9f42a9a72b43.png)

The good news is the new PyPI (aka Warehouse) now supports Markdown for the description, so we can use README.md without conversion!

For more info and examples:
* https://pypi.org/project/markdown-description-example/
* https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi
* https://github.com/di/markdown-description-example
