### PR TITLE
Workaround for a bug in Python 3.5 and 3.6 affecting UDP proxying

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -329,7 +329,7 @@ class socksocket(_BaseSocket):
         Happens during the bind() phase."""
         (proxy_type, proxy_addr, proxy_port, rdns, username,
          password) = self.proxy
-        if not proxy_type or self.type != socket.SOCK_DGRAM:
+        if not proxy_type or self.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE) != socket.SOCK_DGRAM:
             return _orig_socket.bind(self, *pos, **kw)
 
         if self._proxyconn:
@@ -361,7 +361,7 @@ class socksocket(_BaseSocket):
         self.proxy_sockname = ("0.0.0.0", 0)  # Unknown
 
     def sendto(self, bytes, *args, **kwargs):
-        if self.type != socket.SOCK_DGRAM:
+        if self.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE) != socket.SOCK_DGRAM:
             return super(socksocket, self).sendto(bytes, *args, **kwargs)
         if not self._proxyconn:
             self.bind(("", 0))
@@ -381,13 +381,13 @@ class socksocket(_BaseSocket):
         return sent - header.tell()
 
     def send(self, bytes, flags=0, **kwargs):
-        if self.type == socket.SOCK_DGRAM:
+        if self.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE) == socket.SOCK_DGRAM:
             return self.sendto(bytes, flags, self.proxy_peername, **kwargs)
         else:
             return super(socksocket, self).send(bytes, flags, **kwargs)
 
     def recvfrom(self, bufsize, flags=0):
-        if self.type != socket.SOCK_DGRAM:
+        if self.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE) != socket.SOCK_DGRAM:
             return super(socksocket, self).recvfrom(bufsize, flags)
         if not self._proxyconn:
             self.bind(("", 0))
@@ -744,7 +744,7 @@ class socksocket(_BaseSocket):
 
         dest_addr, dest_port = dest_pair
 
-        if self.type == socket.SOCK_DGRAM:
+        if self.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE) == socket.SOCK_DGRAM:
             if not self._proxyconn:
                 self.bind(("", 0))
             dest_addr = socket.gethostbyname(dest_addr)


### PR DESCRIPTION
Python versions 3.5 and 3.6 have a nasty bug related to the socket type.

In these versions, the socket type is sometimes messed up and SOCK_DGRAM (2) becomes 2050.

```
$ python3
Python 3.6.8 (default, Jan 14 2019, 11:02:34) 
[GCC 8.0.1 20180414 (experimental) [trunk revision 259383]] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import socket
>>> sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
>>> sock.type
<SocketKind.SOCK_DGRAM: 2>
>>> sock.settimeout(0)
>>> sock.type
2050
```

(However `sock.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE)` still works as expected and returns the value 2.)

This unfortunately breaks the comparisons with socket.SOCK_DGRAM and makes it impossible to send UDP data through proxies (via UDPASSOCIATE/UDPREPLY). This pull request is intended to fix that, but otherwise does not change functionality. Apparently this Python bug has also been fixed in Python 3.7, but some users of PySocks might also got stuck to older versions, so this might be useful for them.

This Python bug is also briefly described in https://bugs.python.org/issue19422