### PR TITLE
sockshandler: fix socks4 server can not be used by rdns's default value

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -807,6 +807,10 @@ class socksocket(_BaseSocket):
                 # Calls negotiate_{SOCKS4, SOCKS5, HTTP}
                 negotiate = self._proxy_negotiators[proxy_type]
                 negotiate(self, dest_addr, dest_port)
+            except ProxyError:
+                # Protocol error while negotiating with proxy
+                self.close()
+                raise
             except socket.error as error:
                 if not catch_errors:
                     # Wrap socket errors
@@ -814,10 +818,6 @@ class socksocket(_BaseSocket):
                     raise GeneralProxyError("Socket error", error)
                 else:
                     raise error
-            except ProxyError:
-                # Protocol error while negotiating with proxy
-                self.close()
-                raise
                 
     @set_self_blocking
     def connect_ex(self, dest_pair):

--- a/sockshandler.py
+++ b/sockshandler.py
@@ -41,11 +41,11 @@ class SocksiPyConnection(httplib.HTTPConnection):
             # SOCKS4 disable rdns by default
             rdns = proxytype is not socks.SOCKS4
         if rdns:
-            rdns = proxyaddr not in socks4_no_rdns
+            rdns = (proxyaddr, proxyport) not in socks4_no_rdns
         
         while True:
             try:
-                sock = socks.create_connection(
+                self.sock = socks.create_connection(
                         (self.host, self.port), self.timeout, None,
                         proxytype, proxyaddr, proxyport, rdns, username, password,
                         ((socket.IPPROTO_TCP, socket.TCP_NODELAY, 1),))
@@ -55,11 +55,9 @@ class SocksiPyConnection(httplib.HTTPConnection):
                     # Maybe a SOCKS4 server that doesn't support remote resolving
                     # Disable rdns and try again
                     rdns = False
-                    socks4_no_rdns.add(proxyaddr)
+                    socks4_no_rdns.add((proxyaddr, proxyport))
                 else:
                     raise e
-
-        self.sock = sock
 
 class SocksiPyConnectionS(httplib.HTTPSConnection):
     def __init__(self, proxyargs, host, **kwargs):

--- a/sockshandler.py
+++ b/sockshandler.py
@@ -85,7 +85,7 @@ class SocksiPyConnection(httplib.HTTPConnection):
         self.sock = sock
 
 class SocksiPyConnectionS(httplib.HTTPSConnection):
-    def __init__(self, host, proxytype, proxyaddr, proxyport=None, rdns=True, username=None, password=None, **kwargs):
+    def __init__(self, host, proxytype, proxyaddr, proxyport=None, rdns=None, username=None, password=None, **kwargs):
         self.proxyargs = proxytype, proxyaddr, proxyport, rdns, username, password
         httplib.HTTPSConnection.__init__(self, host, **kwargs)
 

--- a/sockshandler.py
+++ b/sockshandler.py
@@ -21,14 +21,9 @@ except ImportError: # Python 3
 import socks # $ pip install PySocks
 
 
-def is_ip(s):
+def is_ipv4(s):
     try:
-        if ':' in s:
-            socket.inet_pton(socket.AF_INET6, s)
-        elif '.' in s:
-            socket.inet_aton(s)
-        else:
-            return False
+        socket.inet_aton(s)
     except:
         return False
     else:
@@ -62,7 +57,7 @@ class SocksiPyConnection(httplib.HTTPConnection):
                 break
             except socks.SOCKS4Error as e:
                 ex = e
-                if rdns and e.msg[:4] == "0x5b" and not is_ip(self.host):
+                if rdns and e.msg[:4] == "0x5b" and not is_ipv4(self.host):
                     # Maybe a SOCKS4 server that doesn't support remote resolving
                     # Disable rdns and try again
                     rdns = False


### PR DESCRIPTION
Solve #134

1. Fixed `socksocket.connect` not be correct for catch `ProxyError` when run in python 3.
2. Disable rdns by default when sockshandler use SOCKS4.
3. Improve on sockshandler's code.

Please tags 1.7.1 befor merge! #133 