### PR TITLE
Remove warning message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,12 +32,12 @@ setup(
     py_modules=["socks", "sockshandler"],
     install_requires=requirements,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-    classifiers=(
+    classifiers=[
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
-    ),
+    ],
 )


### PR DESCRIPTION
The warning is as follows:
Warning: 'classifiers' should be a list, got type 'tuple'

Reference:	https://www.python.org/dev/peps/pep-0301/#distutils-trove-classification