### PR TITLE
change "0" to "0.0.0.0" to fix error when bind udp addr

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -343,7 +343,7 @@ class socksocket(_BaseSocket):
         # some relays drop packets if a port of zero is specified.
         # Avoid specifying host address in case of NAT though.
         _, port = self.getsockname()
-        dst = ("0", port)
+        dst = ("0.0.0.0", port)
 
         self._proxyconn = _orig_socket()
         proxy = self._proxy_addr()


### PR DESCRIPTION
A single "0" is not accepted by `socket.inet_pton`. Use `0.0.0.0` to keep all bits zero.